### PR TITLE
A few visual enhancements when sitting on stairs

### DIFF
--- a/src/main/java/com/bb1/fabric/sit/Loader.java
+++ b/src/main/java/com/bb1/fabric/sit/Loader.java
@@ -59,7 +59,7 @@ public class Loader implements ModInitializer {
             	}
             	BlockState blockState = player.getEntityWorld().getBlockState(new BlockPos(player.getX(), player.getY()-1, player.getZ()));
             	if (player.hasVehicle() || player.isFallFlying() || player.isSleeping() || player.isSwimming() || player.isSpectator() || blockState.isAir() || blockState.getMaterial().isLiquid()) return 0;
-            	Entity entity = createChair(player.getEntityWorld(), player.getBlockPos(), 1.7, player.getPos(), false);
+            	Entity entity = createChair(player.getEntityWorld(), player.getBlockPos(), new Vec3d(0, -1.7, 0), player.getPos(), false);
             	player.startRiding(entity, true);
             	return 1;
             }));
@@ -72,8 +72,8 @@ public class Loader implements ModInitializer {
 		System.out.println("[FabricSit] Loaded! Thank you for using FabricSit");
 	}
 	
-	public static Entity createChair(World world, BlockPos blockPos, double yOffset, @Nullable Vec3d target, boolean boundToBlock) {
-		ArmorStandEntity entity = new ArmorStandEntity(world, 0.5d+blockPos.getX(), blockPos.getY()-yOffset, 0.5d+blockPos.getZ()) {
+	public static Entity createChair(World world, BlockPos blockPos, Vec3d blockPosOffset, @Nullable Vec3d target, boolean boundToBlock) {
+		ArmorStandEntity entity = new ArmorStandEntity(world, 0.5d+blockPos.getX()+blockPosOffset.getX(), blockPos.getY()+ blockPosOffset.getY(), 0.5d+blockPos.getZ() + blockPosOffset.getZ()) {
 			
 			private boolean v = false;
 			

--- a/src/main/java/com/bb1/fabric/sit/mixins/InteractModifier.java
+++ b/src/main/java/com/bb1/fabric/sit/mixins/InteractModifier.java
@@ -10,6 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import com.bb1.fabric.sit.Config;
 import com.bb1.fabric.sit.Loader;
 
+import net.minecraft.block.enums.StairShape;
 import net.minecraft.util.math.*;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -64,8 +65,12 @@ public class InteractModifier {
 		{
 		 	Direction direction = blockState.get(StairsBlock.FACING);
 		 	Vec3f offset = direction.getUnitVector();
+			StairShape stairShape = blockState.get(StairsBlock.SHAPE);
+			if (stairShape == StairShape.OUTER_RIGHT || stairShape == StairShape.INNER_RIGHT)
+				offset.add(direction.rotateYClockwise().getUnitVector());
+			if (stairShape == StairShape.OUTER_LEFT || stairShape == StairShape.INNER_LEFT)
+			 	offset.add(direction.rotateYCounterclockwise().getUnitVector());
 			lookTarget = new Vec3d(blockPos.getX() + 0.5 - offset.getX(), blockPos.getY(), blockPos.getZ() + 0.5 - offset.getZ());
-			System.out.println("hi");
 		}
 		else
 			lookTarget = player.getPos();

--- a/src/main/java/com/bb1/fabric/sit/mixins/InteractModifier.java
+++ b/src/main/java/com/bb1/fabric/sit/mixins/InteractModifier.java
@@ -61,8 +61,8 @@ public class InteractModifier {
 		if (reqDist>0 && (givenDist>(reqDist*reqDist))) { return; }
 
 		Vec3d lookTarget;
-		if (block instanceof StairsBlock)
-		{
+		Vec3d blockPosOffset;
+		if (block instanceof StairsBlock) {
 		 	Direction direction = blockState.get(StairsBlock.FACING);
 		 	Vec3f offset = direction.getUnitVector();
 			StairShape stairShape = blockState.get(StairsBlock.SHAPE);
@@ -71,11 +71,17 @@ public class InteractModifier {
 			if (stairShape == StairShape.OUTER_LEFT || stairShape == StairShape.INNER_LEFT)
 			 	offset.add(direction.rotateYCounterclockwise().getUnitVector());
 			lookTarget = new Vec3d(blockPos.getX() + 0.5 - offset.getX(), blockPos.getY(), blockPos.getZ() + 0.5 - offset.getZ());
+			blockPosOffset = new Vec3d(offset);
+		 	blockPosOffset = blockPosOffset.multiply(-3f/16);
 		}
-		else
+		else {
 			lookTarget = player.getPos();
+			blockPosOffset = Vec3d.ZERO;
+		}
 
-		Entity chair = Loader.createChair(world, blockPos, 1.2, lookTarget, true);
+		blockPosOffset = blockPosOffset.add(0, -1.2, 0);
+		Entity chair = Loader.createChair(world, blockPos, blockPosOffset, lookTarget, true);
+
 		Entity v = player.getVehicle();
 		if (v!=null) {
 			player.setSneaking(true);

--- a/src/main/java/com/bb1/fabric/sit/mixins/InteractModifier.java
+++ b/src/main/java/com/bb1/fabric/sit/mixins/InteractModifier.java
@@ -10,6 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import com.bb1.fabric.sit.Config;
 import com.bb1.fabric.sit.Loader;
 
+import net.minecraft.util.math.*;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SideShapeType;
@@ -22,8 +23,6 @@ import net.minecraft.server.network.ServerPlayerInteractionManager;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
 import net.minecraft.world.GameMode;
 import net.minecraft.world.World;
 /**
@@ -46,7 +45,7 @@ public class InteractModifier {
 	
 	@Shadow public ServerPlayerEntity player;
 	@Shadow public GameMode gameMode;
-	
+
 	@Inject(method = "interactBlock(Lnet/minecraft/server/network/ServerPlayerEntity;Lnet/minecraft/world/World;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/Hand;Lnet/minecraft/util/hit/BlockHitResult;)Lnet/minecraft/util/ActionResult;", at = @At("HEAD"), cancellable = true)
 	public void inject(ServerPlayerEntity player, World world, ItemStack stack, Hand hand, BlockHitResult hitResult, CallbackInfoReturnable<ActionResult> callbackInfoReturnable) {
 		final Config config = Loader.getConfig();
@@ -59,7 +58,19 @@ public class InteractModifier {
 		final double reqDist = config.maxDistanceToSit;
 		double givenDist = blockPos.getSquaredDistance(player.getBlockPos());
 		if (reqDist>0 && (givenDist>(reqDist*reqDist))) { return; }
-		Entity chair = Loader.createChair(world, blockPos, 1.2, player.getPos(), true);
+
+		Vec3d lookTarget;
+		if (block instanceof StairsBlock)
+		{
+		 	Direction direction = blockState.get(StairsBlock.FACING);
+		 	Vec3f offset = direction.getUnitVector();
+			lookTarget = new Vec3d(blockPos.getX() + 0.5 - offset.getX(), blockPos.getY(), blockPos.getZ() + 0.5 - offset.getZ());
+			System.out.println("hi");
+		}
+		else
+			lookTarget = player.getPos();
+
+		Entity chair = Loader.createChair(world, blockPos, 1.2, lookTarget, true);
 		Entity v = player.getVehicle();
 		if (v!=null) {
 			player.setSneaking(true);


### PR DESCRIPTION
Hello! I've made some modifications to make sitting on stairs look a bit better.
1. When sitting on stairs, player's legs will always be facing where the stairs are facing (right now it depends from where the player clicks on the stair block);
2. Additionally, sitting position will be shifted a 3/16th of a block to make sure player's body doesn't look like it's inside the stairs.

 Sitting on the slab or with a /sit command were not affected by these changes.

Before:
![2021-11-17_02 51 20](https://user-images.githubusercontent.com/48105614/142090062-dd5fe458-ad6c-4a43-9c6c-d240b3fbd3eb.png)
![2021-11-17_02 57 06](https://user-images.githubusercontent.com/48105614/142090107-bea49f16-83af-469a-90ba-dc6c9a94c261.png)

After:
![2021-11-17_02 49 49](https://user-images.githubusercontent.com/48105614/142090085-ee56daba-7ca8-4ec0-ba2b-bf7469ba7a3a.png)


