### PR TITLE
A check for an opaque block above the seat

### DIFF
--- a/src/main/java/com/bb1/fabric/sit/Config.java
+++ b/src/main/java/com/bb1/fabric/sit/Config.java
@@ -28,5 +28,7 @@ public class Config extends com.bb1.api.config.Config {
 	@Storable public double maxDistanceToSit = -1;
 	
 	@Storable public boolean requireEmptyHand = true;
-	
+
+	@Storable public boolean noOpaqueBlockAbove = true;
+
 }

--- a/src/main/java/com/bb1/fabric/sit/mixins/InteractModifier.java
+++ b/src/main/java/com/bb1/fabric/sit/mixins/InteractModifier.java
@@ -53,6 +53,9 @@ public class InteractModifier {
 		if (gameMode==GameMode.SPECTATOR || (config.requireEmptyHand && !player.getInventory().getMainHandStack().isEmpty()) || player.isSneaking()) { return; }
 		if (config.requireStanding && player.getVehicle()!=null) { return; }
 		BlockPos blockPos = hitResult.getBlockPos();
+
+		if (config.noOpaqueBlockAbove && world.getBlockState(blockPos.add(0, 1, 0)).isOpaque()) return;
+
 		BlockState blockState = world.getBlockState(blockPos);
 		Block block = blockState.getBlock();
 		if (!(block instanceof StairsBlock || block instanceof SlabBlock) || blockState.isSideSolid(world, blockPos, Direction.UP, SideShapeType.RIGID)) { return; }


### PR DESCRIPTION
Added a new config line that when set to true would only allow to sit on a stair\slab if a block above it isn't opaque.
This helps to prevent people accidentally clicking on, for example, a stair that's used as a wall decoration, and suffocating\getting stuck.